### PR TITLE
Return without setting font if a category is unrecognized

### DIFF
--- a/PresentationMode/IncreaseFontSizePackage.cs
+++ b/PresentationMode/IncreaseFontSizePackage.cs
@@ -78,7 +78,9 @@ namespace PresentationMode
             ErrorHandler.ThrowOnFailure(storage.OpenCategory(category, (uint)(__FCSTORAGEFLAGS.FCSF_LOADDEFAULTS | __FCSTORAGEFLAGS.FCSF_PROPAGATECHANGES)));
             try
             {
-                ErrorHandler.ThrowOnFailure(storage.GetFont(pLOGFONT, pInfo));
+                if (!ErrorHandler.Succeeded(storage.GetFont(pLOGFONT, pInfo)))
+                    return;
+
                 pInfo[0].wPointSize = checked((ushort)(pInfo[0].wPointSize + change));
                 ErrorHandler.ThrowOnFailure(storage.SetFont(pInfo));
                 ErrorHandler.ThrowOnFailure(utilities.FreeFontInfo(pInfo));


### PR DESCRIPTION
@RichieHindle this is slightly different than what you proposed. Can you check it and tell me how it works out for you?

Fixes #4 